### PR TITLE
Avoid jQuery.noConflict(true)

### DIFF
--- a/django_brightcove/static/brightcove/js/brightcove.js
+++ b/django_brightcove/static/brightcove/js/brightcove.js
@@ -1,9 +1,3 @@
-/* Compatibility with Grappelli */
-// grp jQuery namespace
-var grp = grp || {
-    "jQuery": jQuery.noConflict(true)
-};
-
 (function ($) {
     var Brightcove = {
         init: function () {
@@ -17,8 +11,8 @@ var grp = grp || {
             });
         }
     };
-    
+
     $(function () {
         Brightcove.init();
     });
-}(grp.jQuery));
+})(window.jQuery || django.jQuery);


### PR DESCRIPTION
Avoid jQuery.noConflict(true) which should only be done if you are packaging your own copy of jQuery otherwise you could break jQuery for other app, e.g. django.contrib.admin (https://code.djangoproject.com/ticket/16776)
